### PR TITLE
docs: documant mdcTab and related directives

### DIFF
--- a/bundle/src/components/tabs/mdc.tab.bar.directive.ts
+++ b/bundle/src/components/tabs/mdc.tab.bar.directive.ts
@@ -13,6 +13,11 @@ const CLASS_INDICATOR = 'mdc-tab-bar__indicator';
 const CLASS_ICONS_BAR = 'mdc-tab-bar--icon-tab-bar';
 const CLASS_ICONS_WITH_TEXT_BAR = 'mdc-tab-bar--icons-with-text';
 
+/**
+ * Directive for a tab bar. This directive must have <code>mdcTab</code>,
+ * or <code>mdcTabRouter</code> children. The tab bar can optionally be
+ * embedded inside an <code>mdcTabBarScroller</code>.
+ */
 @Directive({
     selector: '[mdcTabBar]'
 })
@@ -20,6 +25,9 @@ export class MdcTabBarDirective {
     @HostBinding('class.' + CLASS_TAB_BAR) _hostClass = true;
     @HostBinding('class.mdc-tab-bar-scroller__scroll-frame__tabs') _insideScrollFrame = false;
     @ContentChildren(AbstractMdcTabDirective, {descendants: false}) _tabs: QueryList<AbstractMdcTabDirective>;
+    /**
+     * Event emitted when the actived tab changes.
+     */
     @Output() tabChange: EventEmitter<MdcTabChange> = new EventEmitter();
     private _indicator: HTMLElement;
     private _adapter: MdcTabBarAdapter = {

--- a/bundle/src/components/tabs/mdc.tab.bar.scroller.directive.ts
+++ b/bundle/src/components/tabs/mdc.tab.bar.scroller.directive.ts
@@ -15,6 +15,11 @@ const CLASS_INDICATOR_BACK = 'mdc-tab-bar-scroller__indicator--back';
 const CLASS_INDICATOR_FORWARD = 'mdc-tab-bar-scroller__indicator--forward';
 const CLASS_SCROLLER_FRAME = 'mdc-tab-bar-scroller__scroll-frame';
 
+/**
+ * Directive for the icon of the back or forward button of a tab bar scroller.
+ * Use this directive on a child element of <code>mdcTabBarScrollerBack</code>,
+ * and <code>mdcTabBarScrollerForward</code>.
+ */
 @Directive({
     selector: '[mdcTabBarScrollerInner]'
 })
@@ -22,6 +27,12 @@ export class MdcTabBarScrollerInnerDirective {
     @HostBinding('class.' + CLASS_INDICATOR_INNER) _hostClass = true;
 }
 
+/**
+ * Directive for the 'back' button of a tab bar scroller. Must be the
+ * first child of an <code>mdcTabBarScroller</code>.
+ * Embed an <code>mdcTabBarScrollerInner</code> inside this directive for the
+ * actual icon.
+ */
 @Directive({
     selector: '[mdcTabBarScrollerBack]'
 })
@@ -33,6 +44,12 @@ export class MdcTabBarScrollerBackDirective {
     }
 }
 
+/**
+ * Directive for the 'forward' button of a tab bar scroller. Must be the
+ * last child of an <code>mdcTabBarScroller</code>.
+ * Embed an <code>mdcTabBarScrollerInner</code> inside this directive for the
+ * actual icon.
+ */
 @Directive({
     selector: '[mdcTabBarScrollerForward]'
 })
@@ -44,6 +61,11 @@ export class MdcTabBarScrollerForwardDirective {
     }
 }
 
+/**
+ * Directive for the 'frame' part (containing the tab bar) of a tab bar scroller.
+ * Must be the child of an <code>mdcTabBarScroller</code>, and have an
+ * <code>mdcTabBar</code> as child.
+ */
 @Directive({
     selector: '[mdcTabBarScrollerFrame]'
 })
@@ -69,6 +91,11 @@ export class MdcTabBarScrollerFrameDirective implements AfterContentInit {
     }
 }
 
+/**
+ * Directive for a scrollable tab bar. Add <code>mdcTabBarScrollerBack</code>,
+ * <code>mdcTabBarScrollerFrame</code>, and <code>mdcTabBarScrollerForward</code>
+ * as children for respectively the back button, scrollable tab bar, and forward button.
+ */
 @Directive({
     selector: '[mdcTabBarScroller]'
 })
@@ -77,7 +104,6 @@ export class MdcTabBarScrollerDirective implements AfterContentInit, OnDestroy {
     @ContentChild(MdcTabBarScrollerBackDirective) _back: MdcTabBarScrollerBackDirective;
     @ContentChild(MdcTabBarScrollerForwardDirective) _forward: MdcTabBarScrollerForwardDirective;
     @ContentChild(MdcTabBarScrollerFrameDirective) _scrollFrame: MdcTabBarScrollerFrameDirective;
-    @Input() direction = 'ltr';
     private _adapter: MdcTabBarScrollerAdapter = {
         addClass: (className: string) => this._rndr.addClass(this._el.nativeElement, className),
         removeClass: (className: string) => this._rndr.removeClass(this._el.nativeElement, className),
@@ -98,7 +124,7 @@ export class MdcTabBarScrollerDirective implements AfterContentInit, OnDestroy {
             if (this._back)
                 this._rndr.removeClass(this._back._el.nativeElement, className);
         },
-        isRTL: () => this.direction === 'rtl',
+        isRTL: () => getComputedStyle(this._el.nativeElement).getPropertyValue('direction') === 'rtl',
         registerBackIndicatorClickHandler: (handler: EventListener) => {
             if (this._back)
                 this.registry.listen(this._rndr, 'click', handler, this._back._el);

--- a/bundle/src/components/tabs/mdc.tab.directive.ts
+++ b/bundle/src/components/tabs/mdc.tab.directive.ts
@@ -7,11 +7,27 @@ import { MdcTabAdapter } from './mdc.tab.adapter';
 import { asBoolean } from '../../utils/value.utils';
 import { MdcEventRegistry } from '../../utils/mdc.event.registry';
 
+/**
+ * The interface for events send by the <code>activate</code> output of an
+ * <code>mdcTab</code> or <code>mdcTabRouter</code> directive, or by
+ * the <code>tabChange</code> event of an <code>mdcTabBar</code>.
+ */
 export interface MdcTabChange {
+    /**
+     * A reference to the tab that sends the event.
+     */
     tab: AbstractMdcTabDirective,
+    /**
+     * The index of the tab that sends the event.
+     */
     tabIndex: number
 }
 
+/**
+ * Directive for an icon when having a tab bar with icons.
+ * This directive must be used as a child of an <code>mdcTab</code>,
+ * or <code>mdcTabRouter</code>.
+ */
 @Directive({
     selector: '[mdcTabIcon]'
 })
@@ -19,6 +35,11 @@ export class MdcTabIconDirective {
     @HostBinding('class.mdc-tab__icon') _hostClass = true;
 }
 
+/**
+ * Directive for the text of tabs, when having a tab bar with icons and text labels.
+ * This directive must be used as a child of an <code>mdcTab</code>, and as a sibbling
+ * to a preceding <code>mdcTabIcon</code>.
+ */
 @Directive({
     selector: '[mdcTabIconText]'
 })
@@ -30,6 +51,9 @@ export class AbstractMdcTabDirective extends AbstractMdcRipple implements OnDest
     @HostBinding('class.mdc-tab') _hostClass = true;
     @ContentChild(MdcTabIconDirective) _mdcTabIcon: MdcTabIconDirective;
     @ContentChild(MdcTabIconTextDirective) _mdcTabIconText: MdcTabIconTextDirective;
+    /**
+     * Event called when the tab is activated.
+     */
     @Output() activate: EventEmitter<MdcTabChange> = new EventEmitter();
     protected _adapter: MdcTabAdapter = {
         addClass: (className: string) => this._rndr.addClass(this._root.nativeElement, className),
@@ -71,6 +95,9 @@ export class AbstractMdcTabDirective extends AbstractMdcRipple implements OnDest
     }
 }
 
+/**
+ * Directive for a tab. This directive must be used as a child of <code>mdcTabBar</code>.
+ */
 @Directive({
     selector: '[mdcTab]',
     providers: [{provide: AbstractMdcTabDirective, useExisting: forwardRef(() => MdcTabDirective) }]
@@ -80,12 +107,17 @@ export class MdcTabDirective extends AbstractMdcTabDirective {
         super(rndr, root, registry);
     }
 
+    /**
+     * Input for activating the tab. Assign a value other than <code>false</code> to activate
+     * the tab. Any other value will have no effect: in order to deatcivate the tab, you must
+     * activate another tab.
+     */
     @Input()
-    get isActive() {
+    get active() {
         return this._active;
     }
 
-    set isActive(value: boolean) {
+    set active(value: boolean) {
         let activate = asBoolean(value);
         if (activate) {
             this._active = true;


### PR DESCRIPTION
Fixes #131

BREAKING CHANGE: The 'isActive' property of mdcTab and mdcTabRouter is renamed to 'active'.