### PR TITLE
feat(ripple): allow customization of ripple styling

### DIFF
--- a/bundle/src/components/ripple/mdc.ripple.directive.ts
+++ b/bundle/src/components/ripple/mdc.ripple.directive.ts
@@ -7,16 +7,21 @@ import { AbstractMdcRipple } from '../ripple/abstract.mdc.ripple';
 import { MdcEventRegistry } from '../../utils/mdc.event.registry';
 
 /**
- * Directive for making an element a ripple surface.
+ * Directive for making an element a ripple surface. The ripple can be customized
+ * with the provided
+ * <a href="https://github.com/material-components/material-components-web/tree/master/packages/mdc-ripple#sass-apis"
+ *   target="_blank">Sass Mixins</a>.
+ * Alternatively you can set the <code>surface</code> to get a default styled ripple.
  */
 @Directive({
     selector: '[mdcRipple]'
 })
 export class MdcRippleDirective extends AbstractMdcRipple implements AfterContentInit, OnDestroy {
     private _initialized = false;
-    @HostBinding('class.mdc-ripple-surface') _on = false;
+    private _on = false;
     private _disabled: boolean = null;
     private _unbounded = false;
+    private _surface = false;
     private _dim = null;
 
     constructor(private elm: ElementRef, private renderer: Renderer2, private registry: MdcEventRegistry) {
@@ -95,6 +100,10 @@ export class MdcRippleDirective extends AbstractMdcRipple implements AfterConten
         }
     }
 
+    @HostBinding('attr.data-mdc-ripple-is-unbounded') get _attrUnbounded() {
+        return this._unbounded ? "" : null;
+    }
+
     /**
      * This input sets the dimension of the ripple.
      * This input can be set to null for returning to the defaults, which uses the surface
@@ -122,6 +131,22 @@ export class MdcRippleDirective extends AbstractMdcRipple implements AfterConten
 
     set disabled(value: any) {
         this._disabled = asBooleanOrNull(value);
+    }
+
+    /**
+     * When this input has a value other than false, the ripple element will get the
+     * "mdc-ripple-surface" class. That class has styling for bounded and unbounded
+     * ripples in accordance with your theme customizations. Without this property,
+     * you have to supply your own ripple styles, using the provided
+     * <a href="https://github.com/material-components/material-components-web/tree/master/packages/mdc-ripple#sass-apis"
+     *   target="_blank">Sass Mixins</a>.
+     */
+    @Input() @HostBinding('class.mdc-ripple-surface') get surface() {
+        return this._surface;
+    }
+
+    set surface(value: any) {
+        this._surface = asBoolean(value);
     }
 
     private reInit() {

--- a/site/src/app/components/directives.demo/utility.directives.component.html
+++ b/site/src/app/components/directives.demo/utility.directives.component.html
@@ -7,8 +7,8 @@ document body, and listen to resize events to update their layout.
 </p>
 <p>
 The layout of following Blox Material directives can be fixed with <code>mdcScrollbarResize</code>:
-<a [routerLink]="['/components/ripple']">mdcRipple</a>
-<a [routerLink]="['/components/slider']">mdcSlider</a>,
+<a [routerLink]="['/components/ripple']">mdcRipple</a>,&ngsp;
+<a [routerLink]="['/components/slider']">mdcSlider</a>,&ngsp;
 <a [routerLink]="['/components/tabs']">mdcTabBar, and mdcTabBarScroller</a>.
 </p>
 

--- a/site/src/app/components/snippets/directives/snippet.card.component.html
+++ b/site/src/app/components/snippets/directives/snippet.card.component.html
@@ -75,7 +75,7 @@
 
     <hr mdcListDivider>
 
-    <a class="custom-card-article" mdcRipple href="javascript:void(0)">
+    <a class="custom-card-article" mdcRipple surface href="javascript:void(0)">
       <h2>Copper on the rise</h2>
       <p>
         Copper price soars amid global market optimism and increased demand.
@@ -84,7 +84,7 @@
 
     <hr mdcListDivider>
 
-    <a class="custom-card-article" mdcRipple href="javascript:void(0)">
+    <a class="custom-card-article" mdcRipple surface href="javascript:void(0)">
       <h2>U.S. tech startups rebound</h2>
       <p>
         Favorable business conditions have allowed startups to secure more fundraising deals compared to last
@@ -94,7 +94,7 @@
 
     <hr mdcListDivider>
 
-    <a class="custom-card-article" mdcRipple href="javascript:void(0)">
+    <a class="custom-card-article" mdcRipple surface href="javascript:void(0)">
       <h2>Asia's clean energy ambitions</h2>
       <p>
         China plans to invest billions of dollars for the development of over 300 clean energy projects in

--- a/site/src/app/components/snippets/directives/snippet.ripple.component.html
+++ b/site/src/app/components/snippets/directives/snippet.ripple.component.html
@@ -1,20 +1,8 @@
 <fieldset class="blox-snippet snippet-skip-line">
-<div tabindex="0" mdcElevation="2"
-  mdcRipple
-  [unbounded]="unbounded"
-  [dimension]="dimension ? 300 : null">Interact with me!</div>
-<section>
-  <div mdcFormField>
-    <div mdcCheckbox>
-      <input mdcCheckboxInput type="checkbox" [(ngModel)]="unbounded"/>
-    </div>
-    <label mdcFormFieldLabel>Unbounded</label>
-  </div>
-  <div mdcFormField>
-    <div mdcCheckbox>
-      <input mdcCheckboxInput type="checkbox" [(ngModel)]="dimension"/>
-    </div>
-    <label mdcFormFieldLabel>Dimension = 300</label>
-  </div>
-</section>
+<div mdcElevation="2" mdcRipple surface tabindex="0">
+    Ripple - Interact with me!
+</div>
+<div mdcElevation="2" mdcRipple surface unbounded tabindex="0">
+    Unbounded Ripple - Interact with me!
+</div>
 </fieldset><div class="snippet-skip-line"></div>

--- a/site/src/app/components/snippets/directives/snippet.ripple.component.scss
+++ b/site/src/app/components/snippets/directives/snippet.ripple.component.scss
@@ -1,4 +1,5 @@
-[mdcRipple] {
+.mdc-ripple-surface {
+    float: left;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -6,9 +7,5 @@
     width: 200px;
     height: 100px;
     padding: 1rem;
-    overflow: hidden;
     cursor: pointer;
-    &.mdc-ripple-upgraded--unbounded {
-        overflow: visible;
-    }
 }

--- a/site/src/app/components/snippets/directives/snippet.ripple.component.ts
+++ b/site/src/app/components/snippets/directives/snippet.ripple.component.ts
@@ -13,10 +13,6 @@ import { AbstractSnippetComponent } from '../abstract.snippet.component';
   styleUrls: ['./snippet.ripple.component.scss']
 })
 export class SnippetRippleComponent/*snip:skip*/extends AbstractSnippetComponent/*snip:endskip*/ {
-    disabled: boolean = null;
-    unbounded = false;
-    dimension = false;
-
     //snip:skip
     constructor() {
         super({

--- a/site/src/app/overview.component.html
+++ b/site/src/app/overview.component.html
@@ -1,7 +1,7 @@
 <h1>Components, Directives &amp; Services</h1>
 <nav class="blox-component-list">
   <section *ngFor="let component of components">
-    <a mdcRipple [routerLink]="component.href">
+    <a mdcRipple surface [routerLink]="component.href">
       <div class="blox-component-list-item-img" [innerHTML]="component.img"></div>
       <div class="blox-component-list-item-text">
         <h2>{{component.title}}</h2>


### PR DESCRIPTION
BREAKING CHANGE: the mdcRipple directive does not set the class
mdc-ripple-surface on it's element anymore. This allows for other
classes to be used with mdcRipple, that can be customized with the
provided sass-mixins. For the old behavior, add the `surface` property
to your mdcRipple. This will add the mdc-ripple-surface class as before.