### PR TITLE
feat: add ripples to mdcSelectItem children of interactive mdcSelect

### DIFF
--- a/site/src/app/components/docs/guides.component.html
+++ b/site/src/app/components/docs/guides.component.html
@@ -1,6 +1,6 @@
 <h1>Guides</h1>
 <div mdcList>
-  <a mdcListItem mdcRipple [routerLink]="['gettingstarted']">Getting Started</a>
-  <a mdcListItem mdcRipple [routerLink]="['ie11']">Building for IE11</a>
-  <a mdcListItem mdcRipple [routerLink]="['/components']">Components</a>
+  <a mdcListItem [routerLink]="['gettingstarted']">Getting Started</a>
+  <a mdcListItem [routerLink]="['ie11']">Building for IE11</a>
+  <a mdcListItem [routerLink]="['/components']">Components</a>
 </div>

--- a/site/src/app/components/snippets/directives/snippet.list.component.html
+++ b/site/src/app/components/snippets/directives/snippet.list.component.html
@@ -1,18 +1,18 @@
 <fieldset class="blox-snippet snippet-skip-line">
 <div mdcListGroup>
   <h3 mdcListGroupSubHeader>Connectivity</h3>
-  <ul mdcList [dense]="dense">
-    <li mdcListItem [mdcRipple]="ripple">
+  <ul mdcList [dense]="dense" [nonInteractive]="!interactive">
+    <li mdcListItem>
       <i *ngIf="startDetail" mdcListItemGraphic class="material-icons">network_wifi</i>
       Wi-Fi
       <i *ngIf="endDetail" mdcListItemMeta class="material-icons">signal_wifi_4_bar</i>
     </li>
-    <li mdcListItem [mdcRipple]="ripple">
+    <li mdcListItem>
       <i *ngIf="startDetail" mdcListItemGraphic class="material-icons">bluetooth</i>
       Bluetooth
       <i *ngIf="endDetail" mdcListItemMeta class="material-icons">bluetooth_searching</i>
     </li>
-    <li mdcListItem [mdcRipple]="ripple">
+    <li mdcListItem>
       <i *ngIf="startDetail" mdcListItemGraphic class="material-icons">data_usage</i>
       Data Usage
       <a *ngIf="endDetail" href="javascript:void(0)" mdcListItemMeta class="material-icons">show_chart</a>
@@ -20,14 +20,14 @@
     <li mdcListDivider [inset]="startDetail"></li>
   </ul>
   <h3 mdcListGroupSubHeader>Folders</h3>
-  <ul mdcList [avatarList]="avatar" [dense]="dense">
-    <li mdcListItem [mdcRipple]="ripple">
+  <ul mdcList [avatarList]="avatar" [dense]="dense"  [nonInteractive]="!interactive">
+    <li mdcListItem>
       <i *ngIf="startDetail && !avatar" mdcListItemGraphic class="material-icons">insert_drive_file</i>
       <img *ngIf="avatar" mdcListItemGraphic src="assets/img/mdc-demos/animal1.svg">
       Photos
       <a *ngIf="endDetail" href="javascript:void(0)" mdcListItemMeta class="material-icons">star</a>
     </li>
-    <li mdcListItem [mdcRipple]="ripple">
+    <li mdcListItem>
       <i *ngIf="startDetail && !avatar" mdcListItemGraphic class="material-icons">insert_drive_file</i>
       <img *ngIf="avatar" mdcListItemGraphic src="assets/img/mdc-demos/animal2.svg">
       Movies
@@ -62,8 +62,8 @@
 </div>
 <div mdcFormField>
   <div mdcCheckbox>
-    <input mdcCheckboxInput type="checkbox" [(ngModel)]="ripple" />
+    <input mdcCheckboxInput type="checkbox" [(ngModel)]="interactive" />
   </div>
-  <label mdcFormFieldLabel>Interaction ripple</label>
+  <label mdcFormFieldLabel>Interactive</label>
 </div>    
 </fieldset><div class="snippet-skip-line"></div>

--- a/site/src/app/components/snippets/directives/snippet.list.component.ts
+++ b/site/src/app/components/snippets/directives/snippet.list.component.ts
@@ -17,7 +17,7 @@ export class SnippetListComponent/*snip:skip*/extends AbstractSnippetComponent/*
     endDetail = true;
     avatar = false;
     dense = false;
-    ripple = false;    
+    interactive = true;    
 
     //snip:skip
     constructor() {

--- a/site/src/app/components/snippets/directives/snippet.list.twoline.component.html
+++ b/site/src/app/components/snippets/directives/snippet.list.twoline.component.html
@@ -1,8 +1,8 @@
 <fieldset class="blox-snippet snippet-skip-line">
 <div mdcListGroup>
   <h3 mdcListGroupSubHeader>Connectivity</h3>
-  <ul mdcList [dense]="dense">
-    <li mdcListItem [mdcRipple]="ripple">
+  <ul mdcList [dense]="dense" [nonInteractive]="!interactive">
+    <li mdcListItem>
       <i *ngIf="startDetail" mdcListItemGraphic class="material-icons">network_wifi</i>
       <span mdcListItemText>
         Wi-Fi
@@ -10,7 +10,7 @@
       </span>
       <i *ngIf="endDetail" mdcListItemMeta class="material-icons">signal_wifi_4_bar</i>
     </li>
-    <li mdcListItem [mdcRipple]="ripple">
+    <li mdcListItem>
       <i *ngIf="startDetail" mdcListItemGraphic class="material-icons">bluetooth</i>
       <span mdcListItemText>
         Bluetooth
@@ -18,7 +18,7 @@
       </span>
       <i *ngIf="endDetail" mdcListItemMeta class="material-icons">bluetooth_searching</i>
     </li>
-    <li mdcListItem [mdcRipple]="ripple">
+    <li mdcListItem>
       <i *ngIf="startDetail" mdcListItemGraphic class="material-icons">data_usage</i>
       <span mdcListItemText>
         Data Usage
@@ -29,8 +29,8 @@
     <li mdcListDivider [inset]="startDetail"></li>
   </ul>
   <h3 mdcListGroupSubHeader>Folders</h3>
-  <ul mdcList [avatarList]="avatar" [dense]="dense">
-    <li mdcListItem [mdcRipple]="ripple">
+  <ul mdcList [avatarList]="avatar" [dense]="dense" [nonInteractive]="!interactive">
+    <li mdcListItem>
       <i *ngIf="startDetail && !avatar" mdcListItemGraphic class="material-icons">insert_drive_file</i>
       <img *ngIf="avatar" mdcListItemGraphic src="assets/img/mdc-demos/animal1.svg">
       <span mdcListItemText>
@@ -39,7 +39,7 @@
       </span>
       <a *ngIf="endDetail" href="javascript:void(0)" mdcListItemMeta class="material-icons">star</a>
     </li>
-    <li mdcListItem [mdcRipple]="ripple">
+    <li mdcListItem>
       <i *ngIf="startDetail && !avatar" mdcListItemGraphic class="material-icons">insert_drive_file</i>
       <img *ngIf="avatar" mdcListItemGraphic src="assets/img/mdc-demos/animal2.svg">
       <span mdcListItemText>
@@ -77,8 +77,8 @@
 </div>
 <div mdcFormField>
   <div mdcCheckbox>
-    <input mdcCheckboxInput type="checkbox" [(ngModel)]="ripple" />
+    <input mdcCheckboxInput type="checkbox" [(ngModel)]="interactive" />
   </div>
-  <label mdcFormFieldLabel>Interaction ripple</label>
+  <label mdcFormFieldLabel>Interactive</label>
 </div>  
 </fieldset><div class="snippet-skip-line"></div>

--- a/site/src/app/components/snippets/directives/snippet.list.twoline.component.ts
+++ b/site/src/app/components/snippets/directives/snippet.list.twoline.component.ts
@@ -17,7 +17,7 @@ export class SnippetListTwolineComponent/*snip:skip*/extends AbstractSnippetComp
     endDetail = true;
     avatar = false;
     dense = false;
-    ripple = false;
+    interactive = true;
 
     //snip:skip
     constructor() {


### PR DESCRIPTION
BREAKING CHANGE: when an mdcSelect is interactive (the default), all its
mdcSelectItem children will get an interaction ripple. Previously you had
to add the ripple with the mdcRipple directive. Thus, you should remove
all mdcRipple directives placed an mdcSelectItem directives, as they are
not needed anymore.