### PR TITLE
Remove viewport property from demo source code

### DIFF
--- a/site/src/app/components/code.sample/code.sample.component.ts
+++ b/site/src/app/components/code.sample/code.sample.component.ts
@@ -7,7 +7,7 @@ import { AbstractSnippetComponent } from '../snippets/abstract.snippet.component
   templateUrl: './code.sample.component.html'
 })
 export class CodeSampleComponent implements AfterContentInit {
-    @ContentChild(AbstractSnippetComponent) snippet;
+    @ContentChild(AbstractSnippetComponent) snippet: AbstractSnippetComponent;
     readonly snippetNames: string[] = [];
     active: string;
     hasSource = false;
@@ -89,7 +89,10 @@ export class CodeSampleComponent implements AfterContentInit {
                 'src/main.ts': require('raw-loader!../../../stackblitz.template/src/main.ts.template').default,
                 'src/styles.scss': require('raw-loader!../../../stackblitz.template/src/styles.scss.template').default,
                 'src/index.html': require('raw-loader!../../../stackblitz.template/src/index.html.template').default
-            };            
+            };
+            if (this.snippet.options.noBodyMargins)
+                files['src/styles.scss'] = files['src/styles.scss'].replace('body {', 'body {\n  margin: 0;');
+
             for (let name in this.snippet.code) {
                 if (this.snippet.code.hasOwnProperty(name) && name.indexOf('.') !== -1)
                     files[`src/app/${name}`] = this.snippet.code[name];

--- a/site/src/app/components/snippets/abstract.snippet.component.ts
+++ b/site/src/app/components/snippets/abstract.snippet.component.ts
@@ -5,7 +5,8 @@ export class AbstractSnippetComponent {
     public disableStackblitz = false;
     public cacheAssets: {[key: string]: string};
 
-    constructor(public code: {[key: string]: string}, cacheAssets: {[key: string]: string} = {}, rootTs = 'typescript') {
+    constructor(public code: {[key: string]: string}, cacheAssets: {[key: string]: string} = {}, rootTs = 'typescript',
+            public options: {noBodyMargins?: boolean} = {}) {
         for (let name in code) {
             if (code.hasOwnProperty(name))
                 code[name] = this.rewrite(code[name]);
@@ -14,6 +15,7 @@ export class AbstractSnippetComponent {
         this.mainComponent = this.extract(code[rootTs], /export\s+class\s+([a-zA-Z0-9_]+Component)/);
         this.mainImport = this.extract(code[rootTs], /templateUrl\s*\:\s*['"]\.\/([^'"]+)\.html['"]/);
         this.cacheAssets = cacheAssets;
+        this.options = options;
     }
 
     rewrite(value: string | {default}): string {

--- a/site/src/app/components/snippets/directives/snippet.drawer.below.component.html
+++ b/site/src/app/components/snippets/directives/snippet.drawer.below.component.html
@@ -33,7 +33,7 @@ snippet-skip-line -->
     </aside>
     <div mdcDrawerScrim *ngIf="drawerType === 'modal'"></div>
 
-    <main [mdcDrawerAppContent]="drawerType === 'dismissible'" #content class="blox-demo-main">
+    <main [mdcDrawerAppContent]="drawerType === 'dismissible'" class="blox-demo-main">
       <h1>{{drawerType | titlecase}} Drawer</h1>
       <p>Click the menu icon above to {{open ? 'close' : 'open'}} the drawer, or use the controls below:</p>
       <div mdcFormField>

--- a/site/src/app/components/snippets/directives/snippet.drawer.below.component.html
+++ b/site/src/app/components/snippets/directives/snippet.drawer.below.component.html
@@ -1,6 +1,10 @@
 <fieldset class="blox-snippet snippet-skip-line">
-<div #viewport class="blox-snippet-page">
-  <header mdcTopAppBar [viewport]="viewport" [fixedAdjust]="content">
+<!-- snippet-skip-line
+<div class="blox-snippet-page">
+  <header mdcTopAppBar [fixedAdjust]="content">
+snippet-skip-line -->
+<div #viewport class="blox-snippet-page snippet-skip-line">
+  <header mdcTopAppBar [viewport]="viewport" [fixedAdjust]="content" class="snippet-skip-line">
     <div mdcTopAppBarRow>
       <section mdcTopAppBarSection alignStart>
         <button mdcIconButton mdcTopAppBarNavIcon class="material-icons" (click)="toggleDrawer()">menu</button>

--- a/site/src/app/components/snippets/directives/snippet.drawer.below.component.scss
+++ b/site/src/app/components/snippets/directives/snippet.drawer.below.component.scss
@@ -18,9 +18,14 @@
 }
 
 //snip:skip
-.mdc-drawer--modal {
-    // the default position is fixed, but in the demo we need to position the drawer
-    // inside its parent, not fixed to the viewport:
-    position: absolute;
-}
+// the default position is fixed, but in the demo we need to position the drawer/scrim
+// inside its parent, not fixed to the viewport:
+.mdc-drawer--modal {position: absolute;}
+// TODO IE 11:
+// - in IE11 the demo's have the scrim only visible over the viewport,
+// and position it wrong when you scroll the page.
+// - we can make the scrim position over the viewport for all browsers
+// if we set "position: absolute" on the scrim, but that requires some more tuning
+// for the drawer.below.component demo to behave nicely, and make the scrim fill
+// the entire viewport.
 //snip:endskip

--- a/site/src/app/components/snippets/directives/snippet.drawer.below.component.scss
+++ b/site/src/app/components/snippets/directives/snippet.drawer.below.component.scss
@@ -1,5 +1,7 @@
 .blox-snippet-page {
-    height: 400px;
+    height: 400px; /* snippet-skip-line
+    height: 100vh;
+    snippet-skip-line */
 }
 
 // Drawer and toolbar and main-content should sit next to each other:
@@ -10,11 +12,15 @@
 }
 
 .blox-demo-main {
+    box-sizing: border-box;
+    height: 100%;
     padding-left: 16px;
 }
 
+//snip:skip
 .mdc-drawer--modal {
-    // the default position is fixed, but in this demo we want to position the drawer
+    // the default position is fixed, but in the demo we need to position the drawer
     // inside its parent, not fixed to the viewport:
     position: absolute;
 }
+//snip:endskip

--- a/site/src/app/components/snippets/directives/snippet.drawer.below.component.ts
+++ b/site/src/app/components/snippets/directives/snippet.drawer.below.component.ts
@@ -22,7 +22,7 @@ export class SnippetDrawerBelowComponent/*snip:skip*/extends AbstractSnippetComp
             'html': require('!raw-loader!./snippet.drawer.below.component.html'),
             'scss': require('!raw-loader!./snippet.drawer.below.component.scss'),
             'typescript': require('!raw-loader!./snippet.drawer.below.component.ts')
-        });
+        }, {}, 'typescript', {noBodyMargins: true});
     }
     //snip:endskip
 

--- a/site/src/app/components/snippets/directives/snippet.drawer.component.html
+++ b/site/src/app/components/snippets/directives/snippet.drawer.component.html
@@ -1,5 +1,8 @@
 <fieldset class="blox-snippet snippet-skip-line">
-<div #viewport class="blox-snippet-page">
+<!-- snippet-skip-line
+<div class="blox-snippet-page">
+snippet-skip-line -->
+<div #viewport class="blox-snippet-page snippet-skip-line">
   <aside [mdcDrawer]="drawerType" [(open)]="open">
     <div mdcDrawerHeader *ngIf="header">
       <h3 mdcDrawerTitle>Header Title</h3>
@@ -31,7 +34,10 @@
   <div mdcDrawerScrim *ngIf="drawerType === 'modal'"></div>
 
   <div [mdcDrawerAppContent]="drawerType === 'dismissible'" class="blox-demo-content">
-    <header mdcTopAppBar [viewport]="viewport" [fixedAdjust]="content">
+<!-- snippet-skip-line
+    <header mdcTopAppBar [fixedAdjust]="content">
+snippet-skip-line -->
+    <header mdcTopAppBar [viewport]="viewport" [fixedAdjust]="content" class="snippet-skip-line">
       <div mdcTopAppBarRow>
         <section mdcTopAppBarSection alignStart>
           <button mdcIconButton mdcTopAppBarNavIcon class="material-icons" (click)="toggleDrawer()">menu</button>

--- a/site/src/app/components/snippets/directives/snippet.drawer.component.scss
+++ b/site/src/app/components/snippets/directives/snippet.drawer.component.scss
@@ -1,26 +1,27 @@
 // Place drawer and content side by side:
 .blox-snippet-page {
     display: flex;
-    flex-direction: row;
-    height: 400px;
+    height: 400px; /* snippet-skip-line
+    height: 100vh;
+    snippet-skip-line */
 }
 
+//snip:skip
 .mdc-drawer--modal {
-    // the default position is fixed, but in this demo we want to position the drawer
+    // the default position is fixed, but in the demo we need to position the drawer
     // inside its parent, not fixed to the viewport:
     position: absolute;
 }
+//snip:endskip
 
 // Stack toolbar and main on top of each other:
 .blox-demo-content {
-    display: inline-flex;
-    flex-direction: column;
-    flex-grow: 1;
-    height: 100%;
-    box-sizing: border-box;
+    flex: auto;
+    overflow: auto;
     position: relative;
 }
 
 .blox-demo-main {
+    box-sizing: border-box;
     padding-left: 16px;
 }

--- a/site/src/app/components/snippets/directives/snippet.drawer.component.scss
+++ b/site/src/app/components/snippets/directives/snippet.drawer.component.scss
@@ -25,3 +25,13 @@
     box-sizing: border-box;
     padding-left: 16px;
 }
+
+//snip:skip
+// TODO IE 11:
+// - in IE11 the demo's have the scrim is only visible on viewport,
+// and position it wrong when you scroll the page.
+// - we can make the scrim position over the viewport for all browsers
+// if we set "position: absolute" on the scrim, but that requires some more tuning
+// for the drawer.below.component demo to behave nicely, and make the scrim fill
+// the entire viewport.
+//snip:endskip

--- a/site/src/app/components/snippets/directives/snippet.drawer.component.ts
+++ b/site/src/app/components/snippets/directives/snippet.drawer.component.ts
@@ -22,7 +22,7 @@ export class SnippetDrawerComponent/*snip:skip*/extends AbstractSnippetComponent
             'html': require('!raw-loader!./snippet.drawer.component.html'),
             'scss': require('!raw-loader!./snippet.drawer.component.scss'),
             'typescript': require('!raw-loader!./snippet.drawer.component.ts')
-        });
+        }, {}, 'typescript', {noBodyMargins: true});
     }
     //snip:endskip
 

--- a/site/src/app/components/snippets/directives/snippet.menu.component.html
+++ b/site/src/app/components/snippets/directives/snippet.menu.component.html
@@ -1,12 +1,17 @@
 <fieldset class="blox-snippet snippet-skip-line">
-<div class="snippet-container" #viewport>
+<!-- snippet-skip-line
+<div class="snippet-container">
+snippet-skip-line -->
+<div class="snippet-container snippet-skip-line" #viewport>
   <div mdcMenuAnchor #anchor [style.top]="pTop" [style.bottom]="pBottom" [style.left]="pLeft" [style.right]="pRight">
     <button mdcButton raised [mdcMenuTrigger]="menu">Reveal Menu</button>
+<!-- snippet-skip-line
     <div mdcMenu #menu="mdcMenu"
+snippet-skip-line -->
+    <div mdcMenu #menu="mdcMenu" [viewport]="viewport" class="snippet-skip-line"
         [(open)]="open"
         [menuAnchor]="anchor"
-        (pick)="select($event.value)"
-        [viewport]="viewport">
+        (pick)="select($event.value)">
       <ul mdcList>
         <li mdcListItem value="back"><span mdcListItemText>Back</span></li>
         <li mdcListItem disabled value="forward"><span mdcListItemText>Forward</span></li>

--- a/site/src/app/components/snippets/directives/snippet.top-app-bar.component.html
+++ b/site/src/app/components/snippets/directives/snippet.top-app-bar.component.html
@@ -1,38 +1,10 @@
 <div class="blox-snippet snippet-skip-line">
-<div mdcFormField>
-  <div mdcRadio>
-    <input mdcRadioInput type="radio" name="type" value="default" [(ngModel)]="type" />
-  </div>
-  <label mdcFormFieldLabel>Default</label>
-</div>
-<div mdcFormField>
-  <div mdcRadio>
-    <input mdcRadioInput type="radio" name="type" value="fixed" [(ngModel)]="type" />
-  </div>
-  <label mdcFormFieldLabel>Fixed</label>
-</div>
-<div mdcFormField>
-  <div mdcRadio>
-    <input mdcRadioInput type="radio" name="type" value="short" [(ngModel)]="type" />
-  </div>
-  <label mdcFormFieldLabel>Short</label>
-</div>
-
-<div mdcFormField>
-  <div mdcCheckbox>
-    <input mdcCheckboxInput type="checkbox" [(ngModel)]="prominent"/>
-  </div>
-  <label mdcFormFieldLabel>Prominent</label>
-</div>
-<div mdcFormField>
-  <div mdcCheckbox>
-    <input mdcCheckboxInput type="checkbox" [(ngModel)]="dense"/>
-  </div>
-  <label mdcFormFieldLabel>Dense</label>
-</div>
-
-<div #viewport class="blox-snippet-page">
-  <header [mdcTopAppBar]="type" [viewport]="viewport" [fixedAdjust]="fixedAdjust"
+<!-- snippet-skip-line
+<div class="blox-snippet-page">
+  <header [mdcTofpAppBar]="type" [fixedAdjust]="fixedAdjust"
+snippet-skip-line -->
+<div #viewport class="blox-snippet-page snippet-skip-line">
+  <header [mdcTopAppBar]="type" [viewport]="viewport" [fixedAdjust]="fixedAdjust" class="snippet-skip-line"
       [prominent]="prominent" [dense]="dense">
     <div mdcTopAppBarRow>
       <section mdcTopAppBarSection alignStart>
@@ -47,6 +19,37 @@
     </div>
   </header>
   <main #fixedAdjust>
+    <div mdcFormField>
+      <div mdcRadio>
+        <input mdcRadioInput type="radio" name="type" value="default" [(ngModel)]="type" />
+      </div>
+      <label mdcFormFieldLabel>Default</label>
+    </div>
+    <div mdcFormField>
+      <div mdcRadio>
+        <input mdcRadioInput type="radio" name="type" value="fixed" [(ngModel)]="type" />
+      </div>
+      <label mdcFormFieldLabel>Fixed</label>
+    </div>
+    <div mdcFormField>
+      <div mdcRadio>
+        <input mdcRadioInput type="radio" name="type" value="short" [(ngModel)]="type" />
+      </div>
+      <label mdcFormFieldLabel>Short</label>
+    </div>
+    
+    <div mdcFormField>
+      <div mdcCheckbox>
+        <input mdcCheckboxInput type="checkbox" [(ngModel)]="prominent"/>
+      </div>
+      <label mdcFormFieldLabel>Prominent</label>
+    </div>
+    <div mdcFormField>
+      <div mdcCheckbox>
+        <input mdcCheckboxInput type="checkbox" [(ngModel)]="dense"/>
+      </div>
+      <label mdcFormFieldLabel>Dense</label>
+    </div>
     <p *ngFor="let i of [1,2,3,4,5,6,7,8,9,10]" class="blox-demo-paragraph">
       Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
       Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante.

--- a/site/src/app/components/snippets/directives/snippet.top-app-bar.component.html
+++ b/site/src/app/components/snippets/directives/snippet.top-app-bar.component.html
@@ -1,7 +1,7 @@
 <div class="blox-snippet snippet-skip-line">
 <!-- snippet-skip-line
 <div class="blox-snippet-page">
-  <header [mdcTofpAppBar]="type" [fixedAdjust]="fixedAdjust"
+  <header [mdcTopAppBar]="type" [fixedAdjust]="fixedAdjust"
 snippet-skip-line -->
 <div #viewport class="blox-snippet-page snippet-skip-line">
   <header [mdcTopAppBar]="type" [viewport]="viewport" [fixedAdjust]="fixedAdjust" class="snippet-skip-line"

--- a/site/src/app/components/snippets/directives/snippet.top-app-bar.component.scss
+++ b/site/src/app/components/snippets/directives/snippet.top-app-bar.component.scss
@@ -1,6 +1,5 @@
 .blox-snippet-page {
-    position: relative;
-    width: 100%;
-    height: 350px;
-    overflow-y: auto;
+    height: 350px; /* snippet-skip-line
+    height: 100vh;
+    snippet-skip-line */
 }

--- a/site/src/app/components/snippets/directives/snippet.top-app-bar.component.ts
+++ b/site/src/app/components/snippets/directives/snippet.top-app-bar.component.ts
@@ -24,7 +24,7 @@ export class SnippetTopAppBarComponent/*snip:skip*/extends AbstractSnippetCompon
           'html': require('!raw-loader!./snippet.top-app-bar.component.html'),
           'scss': require('!raw-loader!./snippet.top-app-bar.component.scss'), // why? it's already in the default stylesheet...
           'typescript': require('!raw-loader!./snippet.top-app-bar.component.ts')
-        });
+        }, {}, 'typescript', {noBodyMargins: true});
     }
     //snip:endskip
 }

--- a/site/src/app/components/theme/theme.switcher.component.html
+++ b/site/src/app/components/theme/theme.switcher.component.html
@@ -1,9 +1,9 @@
-<div mdcMenuAnchor #anchor>
+<div mdcMenuAnchor>
   <button mdcIconButton class="material-icons"
     title="Change theme"
     [disabled]="!themes.length"
     [mdcMenuTrigger]="changeTheme">format_color_fill</button>
-  <div mdcMenu #changeTheme="mdcMenu" [menuAnchor]="anchor" (pick)="setTheme($event.value)">
+  <div mdcMenu #changeTheme="mdcMenu" (pick)="setTheme($event.value)">
     <ul mdcList>
       <li *ngFor="let key of themes" mdcListItem [value]="key">
         <div mdcRadio>

--- a/site/src/style/_base.scss
+++ b/site/src/style/_base.scss
@@ -63,6 +63,7 @@ span.blox-inline-svg {
 }
 
 // don't show all sample drawers above the scrim if we have one active modal drawer:
+// (this makes the scrim also go under the page header, no way around this)
 .blox-main .mdc-drawer {
   z-index: initial;
 


### PR DESCRIPTION
Library users copy the "viewport" property assignments, that are only needed for proper layout inside the demo divs. There are drwabacks when using them for full page designs. When this is removed from the source code users see in our demo's (including stackblitz), they are less likely to copy that code to their own apps.